### PR TITLE
Modify configuration files for load testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ a VPC with 3 private subnet. Required parameters needed by [next step](#deploy-s
 is also provided as stack output.
 
 ```bash
-    sam build -t rds-with-proxy.yaml --use-container
-    sam deploy -t rds-with-proxy.yaml --guided
+    samlocal build -t rds-with-proxy.yaml --use-container
+    samlocal deploy -t rds-with-proxy.yaml --guided
 ```
 ## Deploy serverless workload using RDS Aurora as backend
 
@@ -48,8 +48,8 @@ To build and deploy your application for the first time, run the following in yo
 Pass required parameters during guided deploy.
 
 ```bash
-    sam build --use-container
-    sam deploy --guided
+    samlocal build --use-container
+    samlocal deploy --guided
 ```
 
 

--- a/load-no-proxy.yml
+++ b/load-no-proxy.yml
@@ -1,9 +1,8 @@
 config:
-  target: "https://jczw4vfi35.execute-api.us-east-1.amazonaws.com"
+  target: "https://b53947d2.execute-api.localhost.localstack.cloud:4566"
   phases:
-    - duration: 120
-      arrivalRate: 100
-
+    - duration: 10
+      arrivalRate: 1
 scenarios:
   - name: "Call Function backed by RDS without using RDS Proxy"
     flow:

--- a/load-proxy.yml
+++ b/load-proxy.yml
@@ -1,9 +1,8 @@
 config:
-  target: "https://jczw4vfi35.execute-api.us-east-1.amazonaws.com"
+  target: "https://b53947d2.execute-api.localhost.localstack.cloud:4566"
   phases:
-    - duration: 120
-      arrivalRate: 100
-
+    - duration: 10
+      arrivalRate: 1
 scenarios:
   - name: "Call Function backed by RDS using RDS Proxy"
     flow:

--- a/rds-with-proxy.yaml
+++ b/rds-with-proxy.yaml
@@ -5,17 +5,21 @@ Description: Amazon Aurora MySQL and RDS Proxy Setup
 Mappings:
   NetworkSettings:
     global:
-      vpcCidr: 172.31.0.0/16
-      subPrv1Cidr: 172.31.0.0/24
-      subPrv2Cidr: 172.31.1.0/24
-      subPrv3Cidr: 172.31.2.0/24
+      vpcCidr: 192.168.0.0/16
+      subPrv1Cidr: 192.168.0.0/24
+      subPrv2Cidr: 192.168.1.0/24
+      subPrv3Cidr: 192.168.2.0/24
+      # vpcCidr: 172.31.0.0/16
+      # subPrv1Cidr: 172.31.0.0/24
+      # subPrv2Cidr: 172.31.1.0/24
+      # subPrv3Cidr: 172.31.2.0/24
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.09.1
+      dbVersion: 5.7.mysql_aurora.2.11.2 #5.7.mysql_aurora.2.09.1
       dbEngine: aurora-mysql
       dbFamily: aurora-mysql5.7
-      port: 3306
+      port: 4510
       nodeType: db.r5.large
 
 Resources:

--- a/template.yaml
+++ b/template.yaml
@@ -21,7 +21,7 @@ Parameters:
   Port:
     Type: Number
     Description: "Database port. For Mysql 3306 is default."
-    Default: 3306
+    Default: 4510
   SecretArn:
     Type: String
     Description: "Secret ARN where database credentials are stored."
@@ -51,7 +51,7 @@ Resources:
     Condition: CreateLambdaSg
     Properties:
       GroupDescription: Security Groups for the AWS Lambda for accessing RDS/Proxy
-      GroupName: 'lambda-sg'
+      GroupName: 'lambda-gs'
       SecurityGroupEgress:
         - CidrIp: "0.0.0.0/0"
           FromPort: 0


### PR DESCRIPTION
This PR 
- Updates target configurations of load testing yaml files for `/proxy` and `/no-proxy`. 
- Updates `README.md ` with localstack `sam`. 
- Updates Cidr range. 
- Change default db port from `3306` to `4510`. 
- Update the security group name. 