### PR TITLE
Change the database used from mysql to postgres

### DIFF
--- a/rds-with-proxy.yaml
+++ b/rds-with-proxy.yaml
@@ -9,16 +9,12 @@ Mappings:
       subPrv1Cidr: 192.168.0.0/24
       subPrv2Cidr: 192.168.1.0/24
       subPrv3Cidr: 192.168.2.0/24
-      # vpcCidr: 172.31.0.0/16
-      # subPrv1Cidr: 172.31.0.0/24
-      # subPrv2Cidr: 172.31.1.0/24
-      # subPrv3Cidr: 172.31.2.0/24
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.11.2 #5.7.mysql_aurora.2.09.1
-      dbEngine: aurora-mysql
-      dbFamily: aurora-mysql5.7
+      dbVersion: "13.4"
+      dbEngine: aurora-postgresql
+      dbFamily: aurora-postgresql13.4
       port: 4510
       nodeType: db.r5.large
 
@@ -206,6 +202,7 @@ Resources:
       EnableCloudwatchLogsExports: [ error, slowquery ]
       BacktrackWindow: 86400
       EnableIAMDatabaseAuthentication: true
+      PubliclyAccessible: true
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-mysql-cluster"
@@ -221,7 +218,8 @@ Resources:
       Engine: !FindInMap [ ClusterSettings, global, dbEngine ]
       MonitoringInterval: 1
       MonitoringRoleArn: !GetAtt roleEnhancedMonitoring.Arn
-      PubliclyAccessible: false
+      PubliclyAccessible: true
+      EnableIAMDatabaseAuthentication: true
       EnablePerformanceInsights: true
       PerformanceInsightsRetentionPeriod: 7
       Tags:
@@ -239,7 +237,8 @@ Resources:
       Engine: !FindInMap [ ClusterSettings, global, dbEngine ]
       MonitoringInterval: 1
       MonitoringRoleArn: !GetAtt roleEnhancedMonitoring.Arn
-      PubliclyAccessible: false
+      PubliclyAccessible: true
+      EnableIAMDatabaseAuthentication: true
       EnablePerformanceInsights: true
       PerformanceInsightsRetentionPeriod: 7
       Tags:
@@ -305,6 +304,9 @@ Outputs:
   vpcId:
     Description: "VPC id"
     Value: !Ref vpc
+  subnetIds:
+    Description: "Subnet ids"
+    Value: !Join [ ",", [ !Ref sub1Private, !Ref sub2Private, !Ref sub3Private ] ]
   sub1Private:
     Description: "Private subnet 1"
     Value: !Ref sub1Private

--- a/rds/requirements.txt
+++ b/rds/requirements.txt
@@ -1,2 +1,1 @@
-pymysql
-aws-lambda-powertools
+psycopg2-binary

--- a/rdsproxy/app.py
+++ b/rdsproxy/app.py
@@ -2,17 +2,17 @@ import json
 import boto3
 from os import environ
 
-import pymysql
+import psycopg2
 
-
-client = boto3.client('rds')  # get the rds object
+localstackHost = f"http://{environ.get('LOCALSTACK_HOSTNAME')}:{environ.get('EDGE_PORT')}"
+client = boto3.client('rds', endpoint_url=localstackHost)  # get the rds object
 
 
 def create_proxy_connection_token(username):
     # get the required parameters to create a token
     region = environ.get('region')  # get the region
-    hostname = environ.get('rds_endpoint')  # get the rds proxy endpoint
-    port = environ.get('port')  # get the database port
+    hostname = environ.get('LOCALSTACK_HOSTNAME')  # get the rds proxy endpoint
+    port = 4510 # get the database port
 
     # generate the authentication token -- temporary password
     token = client.generate_db_auth_token(
@@ -26,23 +26,21 @@ def create_proxy_connection_token(username):
 
 
 def db_ops():
-    username = environ.get('username')
+    username = "test_iam_user"
 
     token = create_proxy_connection_token(username)
 
     try:
         # create a connection object
-        connection = pymysql.connect(
-            host=environ.get('rds_endpoint'),
-            # getting the rds proxy endpoint from the environment variables
+        connection = psycopg2.connect(
+            host=environ.get('LOCALSTACK_HOSTNAME'),
+            database=environ.get('database'),
             user=username,
             password=token,
-            db=environ.get('database'),
-            charset='utf8mb4',
-            cursorclass=pymysql.cursors.DictCursor,
-            ssl={"use": True}
+            port= 4510,
         )
-    except pymysql.MySQLError as e:
+
+    except psycopg2.Error as e:
         print(e)
         return e
 
@@ -51,8 +49,9 @@ def db_ops():
 
 def lambda_handler(event, context):
     conn = db_ops()
+    print("connection rds proxy : ", conn)
     cursor = conn.cursor()
-    query = "select curdate() from dual"
+    query = "SELECT version()"
     cursor.execute(query)
     results = cursor.fetchmany(1)
 

--- a/rdsproxy/requirements.txt
+++ b/rdsproxy/requirements.txt
@@ -1,1 +1,1 @@
-pymysql
+psycopg2-binary


### PR DESCRIPTION
This PR: 
- updates the configurations in yaml files to use `postgresql`.
- modify cluster settings to use `EnableIAMDatabaseAuthentication` and make database `PubliclyAccessible`. 
- modify output to give subnet ids in response.
- modify the entire app for `/proxy` and `/no-proxy` to use `postgresql`.