### PR TITLE
fix: get CI green and add integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,9 +44,9 @@ jobs:
       
       - name: Install yq
         run: |
-          sudo add-apt-repository ppa:rmescandon/yq
-          sudo apt update
-          sudo apt install yq -y
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
       
       - name: Install jq
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,22 @@ jobs:
           sleep 20
           samlocal list stack-outputs --stack-name sam-app --region us-east-1  --output json
 
+      - name: Run integration tests
+        run: |
+          set -euo pipefail
+          api_id=$(samlocal list stack-outputs --stack-name sam-app --region us-east-1 --output json \
+            | jq -r '.[] | select(.OutputKey=="ApiBasePath") | .OutputValue' \
+            | sed -E 's#https?://##; s#\..*##')
+          base="https://${api_id}.execute-api.localhost.localstack.cloud:4566"
+          echo "API base: $base"
+
+          for path in /no-proxy /proxy; do
+            echo "GET $path"
+            body=$(curl -fsS --retry 5 --retry-delay 3 --retry-connrefused "${base}${path}")
+            echo "  -> $body"
+            echo "$body" | grep -q PostgreSQL || { echo "::error::$path did not return a PostgreSQL row"; exit 1; }
+          done
+
       - name: Send a Slack notification
         if: failure() || github.event_name != 'pull_request'
         uses: ravsamhq/notify-slack-action@v2

--- a/rds-with-proxy.yaml
+++ b/rds-with-proxy.yaml
@@ -12,9 +12,9 @@ Mappings:
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: "13.4"
+      dbVersion: "13.16"
       dbEngine: aurora-postgresql
-      dbFamily: aurora-postgresql13.4
+      dbFamily: aurora-postgresql13
       port: 4510
       nodeType: db.r5.large
 
@@ -166,16 +166,14 @@ Resources:
   pgNodeParams:
     Type: "AWS::RDS::DBParameterGroup"
     Properties:
-      Description: !Sub "${AWS::StackName}-mysql-node-params"
+      Description: !Sub "${AWS::StackName}-postgres-node-params"
       Family: !FindInMap [ ClusterSettings, global, dbFamily ]
       Parameters:
-        innodb_stats_persistent_sample_pages: "256"
-        slow_query_log: "1"
-        long_query_time: "10"
-        log_output: FILE
+        log_min_duration_statement: "10000"
+        log_statement: "ddl"
       Tags:
         - Key: Name
-          Value: !Sub "${AWS::StackName}-mysql-node-params"
+          Value: !Sub "${AWS::StackName}-postgres-node-params"
   dbSubnets:
     Type: "AWS::RDS::DBSubnetGroup"
     Properties:
@@ -199,8 +197,7 @@ Resources:
       DatabaseName: !FindInMap [ ClusterSettings, global, dbSchema ]
       StorageEncrypted: true
       VpcSecurityGroupIds: [ !Ref dbClusterSecGroup ]
-      EnableCloudwatchLogsExports: [ error, slowquery ]
-      BacktrackWindow: 86400
+      EnableCloudwatchLogsExports: [ postgresql ]
       EnableIAMDatabaseAuthentication: true
       PubliclyAccessible: true
       Tags:
@@ -273,7 +270,7 @@ Resources:
       Auth:
         - { AuthScheme: SECRETS, SecretArn: !Ref secretClusterMasterUser, IAMAuth: REQUIRED }
       DBProxyName: 'rds-proxy'
-      EngineFamily: 'MYSQL'
+      EngineFamily: 'POSTGRESQL'
       RoleArn: !GetAtt dbProxyRole.Arn
       IdleClientTimeout: 120
       RequireTLS: true


### PR DESCRIPTION
## Summary
Get this sample working again on LocalStack and in CI. Fixes [DEVREL-194](https://linear.app/localstack/issue/DEVREL-194/create-infra-on-localstack-fails-for-sample-app)

### CI fixes
- **Install yq**: replace the dead `ppa:rmescandon/yq` (no Release file for Ubuntu noble) with the upstream `mikefarah/yq` binary from GitHub releases. This was the original failure on `main`.
- **Integration test step**: after the deploy completes, look up `ApiBasePath` from the `sam-app` stack outputs, curl both `/no-proxy` and `/proxy` via the LocalStack API Gateway URL, and assert the response contains a PostgreSQL version row. CI now fails if either lambda can't reach the cluster or proxy IAM auth is broken — not just if the deploy succeeds.

### Template fixes (`rds-with-proxy.yaml`)
The Aurora PostgreSQL stack was rolling back on `pgNodeParams` and would have failed proxy auth even if it hadn't:
- `dbFamily`: `aurora-postgresql13.4` (invalid family) → `aurora-postgresql13`
- `dbVersion`: `13.4` (unsupported) → `13.16`
- `pgNodeParams`: drop MySQL parameters (`innodb_stats_persistent_sample_pages`, `slow_query_log`, `long_query_time`, `log_output`) and replace with postgres equivalents (`log_min_duration_statement`, `log_statement`).
- `dbCluster`: drop MySQL-only `BacktrackWindow`; switch `EnableCloudwatchLogsExports` from `[error, slowquery]` to `[postgresql]`.
- `dbProxy.EngineFamily`: `MYSQL` → `POSTGRESQL`.
